### PR TITLE
Closes #17 Resolve inconsistent experiment naming in MLflow

### DIFF
--- a/__scratch6/BalancedBrackets.java
+++ b/__scratch6/BalancedBrackets.java
@@ -1,0 +1,80 @@
+package com.thealgorithms.stacks;
+
+import java.util.Stack;
+
+/**
+ * The nested brackets problem is a problem that determines if a sequence of
+ * brackets are properly nested. A sequence of brackets s is considered properly
+ * nested if any of the following conditions are true: - s is empty - s has the
+ * form (U) or [U] or {U} where U is a properly nested string - s has the form
+ * VW where V and W are properly nested strings For example, the string
+ * "()()[()]" is properly nested but "[(()]" is not. The function called
+ * is_balanced takes as input a string S which is a sequence of brackets and
+ * returns true if S is nested and false otherwise.
+ *
+ * @author akshay sharma
+ * @author <a href="https://github.com/khalil2535">khalil2535<a>
+ * @author shellhub
+ */
+final class BalancedBrackets {
+    private BalancedBrackets() {
+    }
+
+    /**
+     * Check if {@code leftBracket} and {@code rightBracket} is paired or not
+     *
+     * @param leftBracket left bracket
+     * @param rightBracket right bracket
+     * @return {@code true} if {@code leftBracket} and {@code rightBracket} is
+     * paired, otherwise {@code false}
+     */
+    public static boolean isPaired(char leftBracket, char rightBracket) {
+        char[][] pairedBrackets = {
+            {'(', ')'},
+            {'[', ']'},
+            {'{', '}'},
+            {'<', '>'},
+        };
+        for (char[] pairedBracket : pairedBrackets) {
+            if (pairedBracket[0] == leftBracket && pairedBracket[1] == rightBracket) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if {@code brackets} is balanced
+     *
+     * @param brackets the brackets
+     * @return {@code true} if {@code brackets} is balanced, otherwise
+     * {@code false}
+     */
+    public static boolean isBalanced(String brackets) {
+        if (brackets == null) {
+            throw new IllegalArgumentException("brackets is null");
+        }
+        Stack<Character> bracketsStack = new Stack<>();
+        for (char bracket : brackets.toCharArray()) {
+            switch (bracket) {
+            case '(':
+            case '[':
+            case '<':
+            case '{':
+                bracketsStack.push(bracket);
+                break;
+            case ')':
+            case ']':
+            case '>':
+            case '}':
+                if (bracketsStack.isEmpty() || !isPaired(bracketsStack.pop(), bracket)) {
+                    return false;
+                }
+                break;
+            default:
+                return false;
+            }
+        }
+        return bracketsStack.isEmpty();
+    }
+}

--- a/__scratch6/ReversePolishNotation.js
+++ b/__scratch6/ReversePolishNotation.js
@@ -1,0 +1,33 @@
+// Wikipedia: https://en.wikipedia.org/wiki/Reverse_Polish_notation
+
+const calcRPN = (expression) => {
+  const operators = {
+    '+': (a, b) => a + b,
+    '-': (a, b) => a - b,
+    '*': (a, b) => a * b,
+    '/': (a, b) => b / a
+  }
+
+  const tokens = expression.split(' ')
+
+  const stack = []
+
+  tokens.forEach((token) => {
+    const operator = operators[token]
+
+    if (typeof operator === 'function') {
+      const a = stack.pop()
+      const b = stack.pop()
+
+      const result = operator(a, b)
+
+      stack.push(result)
+    } else {
+      stack.push(parseFloat(token))
+    }
+  })
+
+  return stack.pop()
+}
+
+export { calcRPN }

--- a/__scratch6/WildcardMatching.java
+++ b/__scratch6/WildcardMatching.java
@@ -1,0 +1,56 @@
+package com.thealgorithms.dynamicprogramming;
+
+/**
+ *
+ * Author: Janmesh Singh
+ * Github: https://github.com/janmeshjs
+
+ * Problem Statement: To determine if the pattern matches the text.
+ * The pattern can include two special wildcard characters:
+ *       ' ? ': Matches any single character.
+ *       ' * ': Matches zero or more of any character sequence.
+ *
+ * Use DP to return True if the pattern matches the entire text and False otherwise
+ *
+ */
+public final class WildcardMatching {
+    private WildcardMatching() {
+    }
+
+    public static boolean isMatch(String text, String pattern) {
+        int m = text.length();
+        int n = pattern.length();
+
+        // Create a DP table to store intermediate results
+        boolean[][] dp = new boolean[m + 1][n + 1];
+
+        // Base case: an empty pattern matches an empty text
+        dp[0][0] = true;
+
+        // Handle patterns starting with '*'
+        for (int j = 1; j <= n; j++) {
+            if (pattern.charAt(j - 1) == '*') {
+                dp[0][j] = dp[0][j - 1];
+            }
+        }
+
+        // Fill the DP table
+        for (int i = 1; i <= m; i++) {
+            for (int j = 1; j <= n; j++) {
+                char textChar = text.charAt(i - 1);
+                char patternChar = pattern.charAt(j - 1);
+
+                if (patternChar == textChar || patternChar == '?') {
+                    dp[i][j] = dp[i - 1][j - 1];
+                } else if (patternChar == '*') {
+                    // '*' can match zero or more characters
+                    dp[i][j] = dp[i - 1][j] || dp[i][j - 1];
+                } else {
+                    dp[i][j] = false;
+                }
+            }
+        }
+        // The result is in the bottom-right cell of the DP table
+        return dp[m][n];
+    }
+}

--- a/__scratch6/aliquot_sum.cpp
+++ b/__scratch6/aliquot_sum.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file
+ * @brief Program to return the [Aliquot
+ * Sum](https://en.wikipedia.org/wiki/Aliquot_sum) of a number
+ *
+ * @details
+ * The Aliquot sum \f$s(n)\f$ of a non-negative integer n is the sum of all
+ * proper divisors of n, that is, all the divisors of n, other than itself.
+ *
+ * Formula:
+ *
+ * \f[
+ *      s(n) = \sum_{d|n, d\neq n}d.
+ * \f]
+ *
+ * For example;
+ *  \f$s(18) = 1 + 2 + 3 + 6 + 9 = 21 \f$
+ *
+ * @author [SpiderMath](https://github.com/SpiderMath)
+ */
+
+#include <cassert>   /// for assert
+#include <cstdint>
+#include <iostream>  /// for IO operations
+
+/**
+ * @brief Mathematical algorithms
+ * @namespace math
+ */
+namespace math {
+
+/**
+ * @brief to return the aliquot sum of a number
+ * @param num The input number
+ */
+uint64_t aliquot_sum(const uint64_t num) {
+    if (num == 0 || num == 1) {
+        return 0;  // The aliquot sum for 0 and 1 is 0
+    }
+
+    uint64_t sum = 0;
+
+    for (uint64_t i = 1; i <= num / 2; i++) {
+        if (num % i == 0) {
+            sum += i;
+        }
+    }
+
+    return sum;
+}
+}  // namespace math
+
+/**
+ * @brief Self-test implementations
+ * @returns void
+ */
+static void test() {
+    // Aliquot sum of 10 is 1 + 2 + 5 = 8
+    assert(math::aliquot_sum(10) == 8);
+    // Aliquot sum of 15 is 1 + 3 + 5 = 9
+    assert(math::aliquot_sum(15) == 9);
+    // Aliquot sum of 1 is 0
+    assert(math::aliquot_sum(1) == 0);
+    // Aliquot sum of 97 is 1 (the aliquot sum of a prime number is 1)
+    assert(math::aliquot_sum(97) == 1);
+
+    std::cout << "All the tests have successfully passed!\n";
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run the self-test implementations
+    return 0;
+}

--- a/__scratch6/stooge_sort.rs
+++ b/__scratch6/stooge_sort.rs
@@ -1,0 +1,63 @@
+fn _stooge_sort<T: Ord>(arr: &mut [T], start: usize, end: usize) {
+    if arr[start] > arr[end] {
+        arr.swap(start, end);
+    }
+
+    if start + 1 >= end {
+        return;
+    }
+
+    let k = (end - start + 1) / 3;
+
+    _stooge_sort(arr, start, end - k);
+    _stooge_sort(arr, start + k, end);
+    _stooge_sort(arr, start, end - k);
+}
+
+pub fn stooge_sort<T: Ord>(arr: &mut [T]) {
+    let len = arr.len();
+    if len == 0 {
+        return;
+    }
+
+    _stooge_sort(arr, 0, len - 1);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sorting::have_same_elements;
+    use crate::sorting::is_sorted;
+
+    #[test]
+    fn basic() {
+        let mut vec = vec![3, 5, 6, 3, 1, 4];
+        let cloned = vec.clone();
+        stooge_sort(&mut vec);
+        assert!(is_sorted(&vec) && have_same_elements(&vec, &cloned));
+    }
+
+    #[test]
+    fn empty() {
+        let mut vec: Vec<i32> = vec![];
+        let cloned = vec.clone();
+        stooge_sort(&mut vec);
+        assert!(is_sorted(&vec) && have_same_elements(&vec, &cloned));
+    }
+
+    #[test]
+    fn reverse() {
+        let mut vec = vec![6, 5, 4, 3, 2, 1];
+        let cloned = vec.clone();
+        stooge_sort(&mut vec);
+        assert!(is_sorted(&vec) && have_same_elements(&vec, &cloned));
+    }
+
+    #[test]
+    fn already_sorted() {
+        let mut vec = vec![1, 2, 3, 4, 5, 6];
+        let cloned = vec.clone();
+        stooge_sort(&mut vec);
+        assert!(is_sorted(&vec) && have_same_elements(&vec, &cloned));
+    }
+}

--- a/__scratch6/union_of_two_arrays.cpp
+++ b/__scratch6/union_of_two_arrays.cpp
@@ -1,0 +1,220 @@
+/**
+ * @file
+ * @brief Implementation for the [Union of two sorted
+ * Arrays](https://en.wikipedia.org/wiki/Union_(set_theory))
+ * algorithm.
+ * @details The Union of two arrays is the collection of all the unique elements
+ * in the first array, combined with all of the unique elements of a second
+ * array. This implementation uses ordered arrays, and an algorithm to correctly
+ * order them and return the result as a new array (vector).
+ * @see intersection_of_two_arrays.cpp
+ * @author [Alvin](https://github.com/polarvoid)
+ */
+
+#include <algorithm>  /// for std::sort
+#include <cassert>    /// for assert
+#include <iostream>   /// for IO operations
+#include <vector>     /// for std::vector
+
+/**
+ * @namespace operations_on_datastructures
+ * @brief Operations on Data Structures
+ */
+namespace operations_on_datastructures {
+
+/**
+ * @brief Prints the values of a vector sequentially, ending with a newline
+ * character.
+ * @param array Reference to the array to be printed
+ * @returns void
+ */
+void print(const std::vector<int32_t> &array) {
+    for (int32_t i : array) {
+        std::cout << i << " ";  /// Print each value in the array
+    }
+    std::cout << "\n";  /// Print newline
+}
+
+/**
+ * @brief Gets the union of two sorted arrays, and returns them in a
+ * vector.
+ * @details An algorithm is used that compares the elements of the two vectors,
+ * appending the one that has a lower value, and incrementing the index for that
+ * array. If one of the arrays reaches its end, all the elements of the other
+ * are appended to the resultant vector.
+ * @param first A std::vector of sorted integer values
+ * @param second A std::vector of sorted integer values
+ * @returns A std::vector of the union of the two arrays, in ascending order
+ */
+std::vector<int32_t> get_union(const std::vector<int32_t> &first,
+                               const std::vector<int32_t> &second) {
+    std::vector<int32_t> res;         ///< Vector to hold the union
+    size_t f_index = 0;               ///< Index for the first array
+    size_t s_index = 0;               ///< Index for the second array
+    size_t f_length = first.size();   ///< Length of first array
+    size_t s_length = second.size();  ///< Length of second array
+    int32_t next = 0;  ///< Integer to store value of the next element
+
+    while (f_index < f_length && s_index < s_length) {
+        if (first[f_index] < second[s_index]) {
+            next = first[f_index];  ///< Append from first array
+            f_index++;              ///< Increment index of second array
+        } else if (first[f_index] > second[s_index]) {
+            next = second[s_index];  ///< Append from second array
+            s_index++;               ///< Increment index of second array
+        } else {
+            next = first[f_index];  ///< Element is the same in both
+            f_index++;              ///< Increment index of first array
+            s_index++;              ///< Increment index of second array too
+        }
+        if ((res.size() == 0) || (next != res.back())) {
+            res.push_back(next);  ///< Add the element if it is unique
+        }
+    }
+    while (f_index < f_length) {
+        next = first[f_index];  ///< Add remaining elements
+        if ((res.size() == 0) || (next != res.back())) {
+            res.push_back(next);  ///< Add the element if it is unique
+        }
+        f_index++;
+    }
+    while (s_index < s_length) {
+        next = second[s_index];  ///< Add remaining elements
+        if ((res.size() == 0) || (next != res.back())) {
+            res.push_back(next);  ///< Add the element if it is unique
+        }
+        s_index++;
+    }
+    return res;
+}
+
+}  // namespace operations_on_datastructures
+
+/**
+ * @namespace tests
+ * @brief Testcases to check Union of Two Arrays.
+ */
+namespace tests {
+using operations_on_datastructures::get_union;
+using operations_on_datastructures::print;
+/**
+ * @brief A Test to check an edge case (two empty arrays)
+ * @returns void
+ */
+void test1() {
+    std::cout << "TEST CASE 1\n";
+    std::cout << "Intialized a = {} b = {}\n";
+    std::cout << "Expected result: {}\n";
+    std::vector<int32_t> a = {};
+    std::vector<int32_t> b = {};
+    std::vector<int32_t> result = get_union(a, b);
+    assert(result == a);  ///< Check if result is empty
+    print(result);        ///< Should only print newline
+    std::cout << "TEST PASSED!\n\n";
+}
+/**
+ * @brief A Test to check an edge case (one empty array)
+ * @returns void
+ */
+void test2() {
+    std::cout << "TEST CASE 2\n";
+    std::cout << "Intialized a = {} b = {2, 3}\n";
+    std::cout << "Expected result: {2, 3}\n";
+    std::vector<int32_t> a = {};
+    std::vector<int32_t> b = {2, 3};
+    std::vector<int32_t> result = get_union(a, b);
+    assert(result == b);  ///< Check if result is equal to b
+    print(result);        ///< Should print 2 3
+    std::cout << "TEST PASSED!\n\n";
+}
+/**
+ * @brief A Test to check correct functionality with a simple test case
+ * @returns void
+ */
+void test3() {
+    std::cout << "TEST CASE 3\n";
+    std::cout << "Intialized a = {4, 6} b = {2, 3}\n";
+    std::cout << "Expected result: {2, 3, 4, 6}\n";
+    std::vector<int32_t> a = {4, 6};
+    std::vector<int32_t> b = {2, 3};
+    std::vector<int32_t> result = get_union(a, b);
+    std::vector<int32_t> expected = {2, 3, 4, 6};
+    assert(result == expected);  ///< Check if result is correct
+    print(result);               ///< Should print 2 3 4 6
+    std::cout << "TEST PASSED!\n\n";
+}
+/**
+ * @brief A Test to check correct functionality with duplicate values
+ * @returns void
+ */
+void test4() {
+    std::cout << "TEST CASE 4\n";
+    std::cout << "Intialized a = {4, 6, 6, 7} b = {2, 3, 4}\n";
+    std::cout << "Expected result: {2, 3, 4, 6, 7}\n";
+    std::vector<int32_t> a = {4, 6, 6, 7};
+    std::vector<int32_t> b = {2, 3, 4};
+    std::vector<int32_t> result = get_union(a, b);
+    std::vector<int32_t> expected = {2, 3, 4, 6, 7};
+    assert(result == expected);  ///< Check if result is correct
+    print(result);               ///< Should print 2 3 4 6 7
+    std::cout << "TEST PASSED!\n\n";
+}
+/**
+ * @brief A Test to check correct functionality with a harder test case
+ * @returns void
+ */
+void test5() {
+    std::cout << "TEST CASE 5\n";
+    std::cout << "Intialized a = {1, 4, 6, 7, 9} b = {2, 3, 5}\n";
+    std::cout << "Expected result: {1, 2, 3, 4, 5, 6, 7, 9}\n";
+    std::vector<int32_t> a = {1, 4, 6, 7, 9};
+    std::vector<int32_t> b = {2, 3, 5};
+    std::vector<int32_t> result = get_union(a, b);
+    std::vector<int32_t> expected = {1, 2, 3, 4, 5, 6, 7, 9};
+    assert(result == expected);  ///< Check if result is correct
+    print(result);               ///< Should print 1 2 3 4 5 6 7 9
+    std::cout << "TEST PASSED!\n\n";
+}
+/**
+ * @brief A Test to check correct functionality with an array sorted using
+ * std::sort
+ * @returns void
+ */
+void test6() {
+    std::cout << "TEST CASE 6\n";
+    std::cout << "Intialized a = {1, 3, 3, 2, 5, 9, 4, 3, 2} ";
+    std::cout << "b = {11, 3, 7, 8, 6}\n";
+    std::cout << "Expected result: {1, 2, 3, 4, 5, 6, 7, 8, 9, 11}\n";
+    std::vector<int32_t> a = {1, 3, 3, 2, 5, 9, 4, 3, 2};
+    std::vector<int32_t> b = {11, 3, 7, 8, 6};
+    std::sort(a.begin(), a.end());  ///< Sort vector a
+    std::sort(b.begin(), b.end());  ///< Sort vector b
+    std::vector<int32_t> result = get_union(a, b);
+    std::vector<int32_t> expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 11};
+    assert(result == expected);  ///< Check if result is correct
+    print(result);               ///< Should print 1 2 3 4 5 6 7 8 9 11
+    std::cout << "TEST PASSED!\n\n";
+}
+}  // namespace tests
+
+/**
+ * @brief Function to test the correctness of get_union() function
+ * @returns void
+ */
+static void test() {
+    tests::test1();
+    tests::test2();
+    tests::test3();
+    tests::test4();
+    tests::test5();
+    tests::test6();
+}
+
+/**
+ * @brief main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run self-test implementations
+    return 0;
+}


### PR DESCRIPTION
17 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.