### PR TITLE
Closes #49 Fix intermittent race condition in feature store data ingestion

### DIFF
--- a/__scratch3/StringAlgo.jl
+++ b/__scratch3/StringAlgo.jl
@@ -1,0 +1,31 @@
+export StringAlgo
+"""
+  StringAlgo
+
+`StringAlgo` in Julia.
+"""
+module StringAlgo
+
+using TheAlgorithms
+
+export contain_substring_with_kmp
+export ispangram
+export detect_anagrams
+export is_palindrome
+export word_count
+export hamming_distance
+export rabin_karp
+export LCS
+export naive_pattern_search
+
+include("detect_anagrams.jl")
+include("is_palindrome.jl")
+include("kmp_substring_search.jl")
+include("pangram.jl")
+include("word_count.jl")
+include("hamming_distance.jl")
+include("rabin_karp.jl")
+include("lcs.jl")
+include("naive_pattern_search.jl")
+
+end

--- a/__scratch3/linked_deque.lua
+++ b/__scratch3/linked_deque.lua
@@ -1,0 +1,108 @@
+-- Linked double-ended queue (deque for short)
+-- Iterable in both directions, constant-time pushing & popping at both ends
+
+local linked_deque = {}
+
+function linked_deque.new()
+	return {} -- empty deque
+end
+
+function linked_deque:empty()
+	return self.head == nil -- boolean
+end
+
+-- Iterators
+
+-- Iterates the queue from head to tail
+function linked_deque:values()
+	local current = self.head
+	return function()
+		if not current then
+			return
+		end
+		local value = current.value
+		current = current.next
+		return value
+	end
+end
+
+-- Iterates the queue values from tail to head
+function linked_deque:rvalues()
+	local current = self.tail
+	return function()
+		if not current then
+			return
+		end
+		local value = current.value
+		current = current.previous
+		return value
+	end
+end
+
+-- Head
+
+function linked_deque:push_head(value)
+	assert(value ~= nil)
+	local next = self.head
+	self.head = { value = value, next = next }
+	if next then
+		next.previous = self.head
+	else
+		self.tail = self.head
+	end
+end
+
+function linked_deque:get_head()
+	if self.head then
+		return self.head.value
+	end
+end
+
+function linked_deque:pop_head()
+	if self:empty() then
+		return
+	end
+	local value = self.head.value
+	if self.head == self.tail then
+		self.head, self.tail = nil, nil
+	else
+		self.head = self.head.next
+		self.head.previous = nil
+	end
+	return value
+end
+
+-- Tail
+
+function linked_deque:push_tail(value)
+	assert(value ~= nil)
+	local previous = self.tail
+	self.tail = { value = value, previous = previous }
+	if previous then
+		previous.next = self.tail
+	else
+		self.head = self.tail
+	end
+end
+
+function linked_deque:get_tail()
+	if self.tail then
+		return self.tail.value
+	end
+end
+
+function linked_deque:pop_tail()
+	if self:empty() then
+		return
+	end
+	local value = self.tail.value
+	if self.head == self.tail then
+		self.head, self.tail = nil, nil
+	else
+		self.tail = self.tail.previous
+		self.tail.next = nil
+	end
+	return value
+end
+
+return require("class")(linked_deque)


### PR DESCRIPTION
49 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.