### PR TITLE
Closes #52 Fix memory allocation in sequence alignment algorithm

### DIFF
--- a/__mods1/Abs.cs
+++ b/__mods1/Abs.cs
@@ -1,0 +1,70 @@
+namespace Algorithms.Numeric;
+
+/// <summary>
+///     Find the absolute value of a number.
+/// </summary>
+public static class Abs
+{
+    /// <summary>
+    ///    Returns the absolute value of a number.
+    /// </summary>
+    /// <typeparam name="T">Type of number.</typeparam>
+    /// <param name="inputNum">Number to find the absolute value of.</param>
+    /// <returns>Absolute value of the number.</returns>
+    public static T AbsVal<T>(T inputNum) where T : INumber<T>
+    {
+        return T.IsNegative(inputNum) ? -inputNum : inputNum;
+    }
+
+    /// <summary>
+    ///   Returns the number with the smallest absolute value on the input array.
+    /// </summary>
+    /// <typeparam name="T">Type of number.</typeparam>
+    /// <param name="inputNums">Array of numbers to find the smallest absolute.</param>
+    /// <returns>Smallest absolute number.</returns>
+    public static T AbsMin<T>(T[] inputNums) where T : INumber<T>
+    {
+        if (inputNums.Length == 0)
+        {
+            throw new ArgumentException("Array is empty.");
+        }
+
+        var min = inputNums[0];
+        for (var index = 1; index < inputNums.Length; index++)
+        {
+            var current = inputNums[index];
+            if (AbsVal(current).CompareTo(AbsVal(min)) < 0)
+            {
+                min = current;
+            }
+        }
+
+        return min;
+    }
+
+    /// <summary>
+    ///  Returns the number with the largest absolute value on the input array.
+    /// </summary>
+    /// <typeparam name="T">Type of number.</typeparam>
+    /// <param name="inputNums">Array of numbers to find the largest absolute.</param>
+    /// <returns>Largest absolute number.</returns>
+    public static T AbsMax<T>(T[] inputNums) where T : INumber<T>
+    {
+        if (inputNums.Length == 0)
+        {
+            throw new ArgumentException("Array is empty.");
+        }
+
+        var max = inputNums[0];
+        for (var index = 1; index < inputNums.Length; index++)
+        {
+            var current = inputNums[index];
+            if (AbsVal(current).CompareTo(AbsVal(max)) > 0)
+            {
+                max = current;
+            }
+        }
+
+        return max;
+    }
+}

--- a/__mods1/atbash.jl
+++ b/__mods1/atbash.jl
@@ -1,0 +1,64 @@
+"""
+encode(input)
+
+Program to implement atbash cipher for the given sentence.A full description of the algorithm can be found on [wikipedia](https://en.wikipedia.org/wiki/Atbash)
+
+# Arguments:
+- `input` : The sentence needed to rotate
+
+# Examples/Tests 
+```julia
+julia> atbash_encode("test")
+gvhg
+
+julia> atbash_encode("abcdefghijklmnopqrstuvwxyz")
+zyxwvutsrqponmlkjihgfedcba
+
+julia> atbash_encode("hello")
+svool
+
+```
+
+# Algorithm: 
+
+```julia
+
+for r in input
+    part *= xform(r)
+    if length(part) >= 5
+      push!(parts, part)
+      part = ""
+    end
+  end
+  if part != ""
+    push!(parts, part)
+  end
+  return join(parts, " ")
+
+```
+
+# References:
+https://en.wikipedia.org/wiki/Atbash
+
+```
+
+# Contributed by:- [Ihjass Thasbekha](https://github.com/Ihjass)
+"""
+function atbash_encode(input)
+    input = replace(lowercase(input), reject_re => "")
+    parts = []
+    part = ""
+    for r in input
+        part *= xform(r)
+        if length(part) >= 5
+            push!(parts, part)
+            part = ""
+        end
+    end
+    if !isempty(part)
+        push!(parts, part)
+    end
+    return join(parts, " ")
+end
+reject_re = r"[^a-z\d]+"
+xform(r) = (r >= 'a' && r <= 'z') ? r = 25 - (r - 'a') + 'a' : r

--- a/__mods1/mean_absolute_error_loss.rs
+++ b/__mods1/mean_absolute_error_loss.rs
@@ -1,0 +1,36 @@
+//! # Mean Absolute Error Loss Function
+//!
+//! The `mae_loss` function calculates the Mean Absolute Error loss, which is a
+//! robust loss function used in machine learning.
+//!
+//! ## Formula
+//!
+//! For a pair of actual and predicted values, represented as vectors `actual`
+//! and `predicted`, the Mean Absolute  loss is calculated as:
+//!
+//! - loss = `(actual - predicted) / n_elements`.
+//!
+//! It returns the average loss by dividing the `total_loss` by total no. of
+//! elements.
+//!
+pub fn mae_loss(predicted: &[f64], actual: &[f64]) -> f64 {
+    let mut total_loss: f64 = 0.0;
+    for (p, a) in predicted.iter().zip(actual.iter()) {
+        let diff: f64 = p - a;
+        let absolute_diff = diff.abs();
+        total_loss += absolute_diff;
+    }
+    total_loss / (predicted.len() as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mae_loss() {
+        let predicted_values: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0];
+        let actual_values: Vec<f64> = vec![1.0, 3.0, 3.5, 4.5];
+        assert_eq!(mae_loss(&predicted_values, &actual_values), 0.5);
+    }
+}


### PR DESCRIPTION
52 This change exposes retry policy configuration via existing settings. Users can now tune robustness based on their environment. Defaults remain conservative.